### PR TITLE
Fixing up the unit tests

### DIFF
--- a/blower_tester/blower_tester/dut_tests.py
+++ b/blower_tester/blower_tester/dut_tests.py
@@ -1,27 +1,26 @@
 from collections import namedtuple
-from time import sleep
+import time
 import subprocess as sp
 from pathlib import Path
 
+from .thermal_monitor import ThermalMonitor 
 from .config import pins, conf, act_hw
 if act_hw(): from smbus2 import SMBus
 
 from .stm32 import do_spi_ack, get_tc_temp, get_fan_speed
-
-from .thermal_monitor import ThermalMonitor, TMStatusPacket
 
 __thermal_monitor = ThermalMonitor(0, 0, 50000, 0)
 
 def pwr_on():
     conf["log"].debug("Asserting power enable pin")
     pins.pwr_en.value = True
-    sleep(3)
+    time.sleep(3)
     __thermal_monitor.start()
 
 def pwr_off():
     conf["log"].debug("De-Asserting power enable pin")
     __thermal_monitor.stop()
-    sleep(0.5)
+    time.sleep(0.5)
     pins.pwr_en.value = False
 
 def prog_mcu():
@@ -44,7 +43,7 @@ def prog_mcu():
     except(OSError, sp.CalledProcessError) as exception:
         conf["log"].error("Exception occured: {}".format(exception))
         err = "An error occurred, cannot program STM32!, check U4"
-    sleep(5)
+    time.sleep(5)
     return err
 
 def spi_ack():
@@ -91,7 +90,7 @@ def _check_fan(fan_num, desired_rpm, fail_designators):
     desired_rpm = int(desired_rpm)
 
     conf["log"].debug("Attempting to spin fan {:d} at {:d} RPM".format(fan_num, desired_rpm))
-    
+
     measured_rpm = int(get_fan_speed(__thermal_monitor, fan_num)) 
 
     conf["log"].debug("Measured fan {:d} RPM: {:d}".format(fan_num, measured_rpm))

--- a/blower_tester/blower_tester/stm32.py
+++ b/blower_tester/blower_tester/stm32.py
@@ -1,6 +1,7 @@
+import time
+
 from .config import conf
-from .thermal_monitor import ThermalMonitor, TMStatusPacket
-from time import time
+from .thermal_monitor import TMStatusPacket
 
 def __fw_version_valid(packet):
     return packet.fw_version_major > 0
@@ -8,8 +9,8 @@ def __fw_version_valid(packet):
 def do_spi_ack(thermal_monitor):
     TIMEOUT_S = 10
     packet = TMStatusPacket()
-    start = time()
-    while not (__fw_version_valid(packet) or (time() - start) > TIMEOUT_S):
+    start = time.time()
+    while not (__fw_version_valid(packet) or (time.time() - start) > TIMEOUT_S):
         thermal_monitor.request_packet()
         packet = thermal_monitor.packet
         if __fw_version_valid(packet):
@@ -17,7 +18,6 @@ def do_spi_ack(thermal_monitor):
             return None
     conf["log"].debug(f"Packet Received: \n{thermal_monitor.packet}")
     return "Could not communicate over SPI"
-
 
 def get_tc_temp(thermal_monitor, tc_ch):
     if tc_ch not in conf["tc"]["range"]:
@@ -41,13 +41,14 @@ def get_fan_speed(thermal_monitor, fan_num):
     else:
         TIMEOUT_S = 10
         packet = TMStatusPacket() 
-        start = time()
-        while not (__fan_speed_valid(packet, fan_num-1) or (time() - start) > TIMEOUT_S):
+        start = time.time()
+        while not (__fan_speed_valid(packet, fan_num-1) or (time.time() - start) > TIMEOUT_S):
             thermal_monitor.request_packet()
             packet = thermal_monitor.packet
             if __fan_speed_valid(packet, fan_num-1):
                 conf["log"].debug(f"Packet Received: \n{thermal_monitor.packet}")
                 fan_speed = thermal_monitor.packet.fan_speed_rpm[fan_num-1]
                 break
+
     conf["log"].debug("Measured fan {:d}, speed: {:d} RPM".format(fan_num, fan_speed))
     return fan_speed

--- a/blower_tester/blower_tester/thermal_monitor.py
+++ b/blower_tester/blower_tester/thermal_monitor.py
@@ -1,4 +1,5 @@
-import spidev
+from .config import act_hw
+if act_hw(): import spidev
 import struct
 
 class TMStatusPacket:
@@ -38,7 +39,7 @@ class ThermalMonitor:
         self.device_id = device_id
         self.clock_speed = clock_speed
         self.spi_mode = spi_mode
-        self.spi_inst = spidev.SpiDev()
+        self.spi_inst = spidev.SpiDev() if act_hw() else None
         self.packet = TMStatusPacket()
 
     def start(self):

--- a/blower_tester/tests/test_dut_tests.py
+++ b/blower_tester/tests/test_dut_tests.py
@@ -3,15 +3,16 @@ from unittest.mock import patch, Mock
 
 from blower_tester import dut_tests
 from blower_tester.config import conf
- 
+
 class TestGroup(TestCase):
     room_temp = 25
 
+    @patch('time.sleep', return_value=None)
     @patch('subprocess.Popen')
-    def test_prog_mcu_pass(self, mock_popen):
+    def test_prog_mcu_pass(self, mock_popen, mock_sleep):
 
         process_mock = Mock()
-        attrs = {"communicate.return_value": 
+        attrs = {"communicate.return_value":
                  (bytearray("output flash written and verified", 'utf-8'), 
                   bytearray("error", 'utf-8'))}
 
@@ -21,12 +22,13 @@ class TestGroup(TestCase):
         err = dut_tests.prog_mcu()
         assert err == None
 
+    @patch('time.sleep', return_value=None)
     @patch('subprocess.Popen')
-    def test_prog_mcu_fail(self, mock_popen):
+    def test_prog_mcu_fail(self, mock_popen, mock_sleep):
 
         process_mock = Mock()
-        attrs = {"communicate.return_value": 
-                 (bytearray("output flash not written", 'utf-8'), 
+        attrs = {"communicate.return_value":
+                 (bytearray("output flash not written", 'utf-8'),
                   bytearray("error", 'utf-8'))}
 
         process_mock.configure_mock(**attrs)
@@ -35,7 +37,8 @@ class TestGroup(TestCase):
         err = dut_tests.prog_mcu()
         assert err
 
-    def test_prog_mcu_error(self):
+    @patch('time.sleep', return_value=None)
+    def test_prog_mcu_error(self, mock_sleep):
         err = dut_tests.prog_mcu()
         assert err
 
@@ -62,28 +65,26 @@ class TestGroup(TestCase):
 
     @patch('blower_tester.dut_tests._tmp1075_temp', return_value=room_temp)
     def test_thermocouple_out_of_range(self, mock_tmp_temp):
-        with self.assertRaises(ValueError): 
-            dut_tests.get_tc_temp(min(conf["tc"]["range"]) - 1)
+        with self.assertRaises(ValueError):
+            dut_tests.get_tc_temp(None, min(conf["tc"]["range"]) - 1)
 
-        with self.assertRaises(ValueError): 
-            dut_tests.get_tc_temp(max(conf["tc"]["range"]) + 1)
+        with self.assertRaises(ValueError):
+            dut_tests.get_tc_temp(None, max(conf["tc"]["range"]) + 1)
 
-    @patch('blower_tester.dut_tests.get_fan_speed', return_value=conf["fan"]["speed"])
-    @patch('blower_tester.dut_tests.set_fan_speed')
-    def test_fan_pass(self, mock_sfs, mock_gfs):
-        err = dut_tests._check_fan(1, conf["fan"]["speed"], 'a,b,c')
+    @patch('blower_tester.dut_tests.get_fan_speed', return_value=conf["fan"]["speed"][1])
+    def test_fan_pass(self, mock_gfs):
+        err = dut_tests._check_fan(1, conf["fan"]["speed"][1], 'a,b,c')
         assert err == None
-    
-    @patch('blower_tester.dut_tests.get_fan_speed', 
-                return_value=(1 - 2 * conf["fan"]["tol"] / 100) * conf["fan"]["speed"])
-    @patch('blower_tester.dut_tests.set_fan_speed')
-    def test_fan_fail(self, mock_sfs, mock_gfs):
-        err = dut_tests._check_fan(1, conf["fan"]["speed"], 'a,b,c')
+
+    @patch('blower_tester.dut_tests.get_fan_speed',
+                return_value=(1 - 2 * conf["fan"]["tol"] / 100) * conf["fan"]["speed"][1])
+    def test_fan_fail(self, mock_gfs):
+        err = dut_tests._check_fan(1, conf["fan"]["speed"][1], 'a,b,c')
         assert err
 
-    def test_thermocouple_out_of_range(self):
-        with self.assertRaises(ValueError): 
-            dut_tests.set_fan_speed(min(conf["fan"]["range"]) - 1, conf["fan"]["speed"])
+    def test_fan_out_of_range(self):
+        with self.assertRaises(ValueError):
+            dut_tests.get_fan_speed(None, min(conf["fan"]["range"]) - 1)
 
-        with self.assertRaises(ValueError): 
-            dut_tests.get_fan_speed(max(conf["fan"]["range"]) + 1)
+        with self.assertRaises(ValueError):
+            dut_tests.get_fan_speed(None, max(conf["fan"]["range"]) + 1)


### PR DESCRIPTION
I made a few changes past what we talked about.

Allow the unit tests to pass and mocked time.sleep so they run faster
Set spidev dependency in the toml file so that it only installs on Linux systems (Windows fails)
Trying the thermocouples and fans only once instead of in a loop
Thanks again for the help.