### PR TITLE
Adding program version

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,9 @@
-export BLOWER_APP_NAME="rpi_blower_app"
-export BLOWER_APP_VERSION="1.0.0"
+export BLOWER_APP_NAME="rpi_blower_tester"
+export BLOWER_APP_VERSION="x.x.x"
+export TERM=linux
 
 export BLOWER_EXEC_FILE="rpi_blower_tester"
 export BLOWER_SERVICE_FILE="blower_tester.service"
 export BLOWER_INSTALL_DIR="/usr/local/" #forward slash at end
 export BLOWER_PY_APP="blower_tester"
+

--- a/blower_tester/blower_tester/__main__.py
+++ b/blower_tester/blower_tester/__main__.py
@@ -18,6 +18,4 @@ log_level = logging.DEBUG if args.verbose else logging.INFO
 logging.basicConfig(format="%(levelname)s:      %(message)s",
                     datefmt='%s', level=log_level)
 
-run("cls" if os.name == 'nt' else "clear", shell=True)
-
 blower_main()

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ function cp_udev_rule {
 function install_main {
   . .env
 
-  echo "Beginning installation of "$BLOWER_APP_NAME" -- Version: "$BLOWER_APP_VERSION")"
+  echo "Beginning installation of "$BLOWER_APP_NAME" -- Version: "$BLOWER_APP_VERSION""
 
   apt-get update
   apt-get install -y git ca-certificates curl

--- a/man.1
+++ b/man.1
@@ -1,31 +1,33 @@
-.Dd 1/6/25               
+.Dd 3/9/25
 .Dt PROG_NAME
-.Sh NAME            
+.Sh NAME
 .Nm PROG_NAME
-.Sh SYNOPSIS             
+.Sh SYNOPSIS
 .Nm
 .Op Fl b
 .Op Fl h
 .Op Fl r
 .Op Fl t
 
-.Sh DESCRIPTION          
+.Sh DESCRIPTION
 .Nm
 is an application for programming and validating Blower/Thermocouple PCBAs (CG5-ELEC-E-019 V2.1+)
 using the Blower/Thermocouple tester (CG5-TEST-E-019) which is intended to run on the Raspberry Pi
-Zero 2W. Prinicipally this was designed as a production tool but can additionally serve for internal 
+Zero 2W. Prinicipally this was designed as a production tool but can additionally serve for internal
 Gastro. use as well. The application can be built and tested but not ran on Debian based Linux distributions.
 
 .Sh OPTIONS
 .Tp
--b, --build  Re-builds the docker container for the application
+-b, --build   Re-builds the docker container for the application
 .sp
--h, --help   Displays the manual page for the program
+-h, --help    Displays the manual page for the program
 .sp
--r, --run    Runs the application. Only supported on the Raspberry Pi Zero 2W 
-using the Blower/Thermocouple tester (CG5-TEST-E-019) 
+-r, --run     Runs the application. Only supported on the Raspberry Pi Zero 2W
+using the Blower/Thermocouple tester (CG5-TEST-E-019)
 .sp
--t, --test   Run the unit tests for the application
+-t, --test    Run the unit tests for the application
+.sp
+-v, --version Prints the version of the application
 .sp
 No arguments defaults to run
 

--- a/rpi_blower_tester
+++ b/rpi_blower_tester
@@ -1,7 +1,7 @@
 SCRIPT_DIR=INSTALL_DIR
 
-unset DOCKER_HOST
-docker context use default
+unset DOCKER_HOST > /dev/null 2>&1
+docker context use default > /dev/null 2>&1
 
 GPIO_GID=$(getent group gpio | cut -d: -f3)
 DIALOUT_GID=$(getent group dialout | cut -d: -f3)
@@ -10,12 +10,17 @@ SPI_GID=$(getent group spi | cut -d: -f3)
 
 . $SCRIPT_DIR/src/*.env
 
+PROG_VERS=$BLOWER_APP_NAME" VERSION: "$BLOWER_APP_VERSION
+
 RUN_CMD="docker run --privileged \
          --group-add $GPIO_GID --group-add $DIALOUT_GID \
          --group-add $I2C_GID  --group-add $SPI_GID \
          -v /dev:/dev -v /sys:/sys -v /proc:/proc --rm -it $BLOWER_APP_NAME"
 
-if [ $# -eq 0 ]; then $RUN_CMD
+if [ $# -eq 0 ]; then
+  clear 
+  printf "$PROG_VERS\n\n"
+  $RUN_CMD
   
 else
   for cmd in "$@"
@@ -34,15 +39,19 @@ else
         ;;
 
       -r|--run)
-        echo "Running "$BLOWER_APP_NAME
+        clear
+        printf "$PROG_VERS\n\n"
         $RUN_CMD
       ;;
 
       -t|--test)
         echo "Testing "$BLOWER_APP_NAME
         docker run --rm $BLOWER_APP_NAME python -m pytest -o cache_dir=$WORKSPACE
-       ;;
+      ;;
 
+     -v|--version)
+        printf "Blower/Thermocouple Application Version: $BLOWER_APP_VERSION\n"
+      ;; 
      -*|--*)
         printf "Unknown command: "$1"\n"
         printf "Perhaps see man page or run "$BLOWER_APP_NAME "--help"


### PR DESCRIPTION
This adds a program version (BLOWER_APP_VERSION) printed to the display as a future-proofing measure.

A flag has also been added to check the version number and the manual page has been updated.
```
rpi_blower_tester -v
rpi_blower_tester --version
```

This was tested on the internal blower/thermocouple tester. A few other adjustments were required to clear the screen properly before the python application starts.